### PR TITLE
Update to geoipupdate 2.5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM gliderlabs/alpine:3.3
 
 MAINTAINER Takeru Sato <midium.size@gmail.com>
 
-ENV GEOIP_UPDATE_VERSION  2.2.2
+ENV GEOIP_UPDATE_VERSION  2.5.0
 ENV SRC_DL_URL_PREF       https://github.com/maxmind/geoipupdate/archive
 ENV GEOIP_CONF_FILE       /usr/etc/GeoIP.conf
 ENV GEOIP_DB_DIR          /usr/share/GeoIP

--- a/GeoIP.conf.tmpl
+++ b/GeoIP.conf.tmpl
@@ -1,6 +1,6 @@
-UserId 999999
+AccountID 0
 LicenseKey 000000000000
-ProductIds 506 533 GeoLite2-City GeoLite2-Country
+EditionIDs GeoLite2-City GeoLite2-Country
 
 # The remaining settings are OPTIONAL.
 


### PR DESCRIPTION
```
/ # /bin/run.sh
geoipupdate 2.5.0
Opened License file /usr/etc/GeoIP.conf
AccountID 0
LicenseKey 000000000000
Insert edition_id GeoLite2-City
Insert edition_id GeoLite2-Country
Read in license key /usr/etc/GeoIP.conf
Number of edition IDs 2
url: https://updates.maxmind.com/app/update_getfilename?product_id=GeoLite2-City
md5hex_digest: 00000000000000000000000000000000
url: https://updates.maxmind.com/app/update_getipaddr
Client IP address: 39.110.218.162
md5hex_digest2 (challenge): cc0e7d8aeb29a3f811a87dceb5b73829
url: https://updates.maxmind.com/app/update_secure?db_md5=00000000000000000000000000000000&challenge_md5=cc0e7d8aeb29a3f811a87dceb5b73829&user_id=0&edition_id=GeoLite2-City
Uncompress file /usr/share/GeoIP/GeoLite2-City.mmdb.gz to /usr/share/GeoIP/GeoLite2-City.mmdb.test
Rename /usr/share/GeoIP/GeoLite2-City.mmdb.test to /usr/share/GeoIP/GeoLite2-City.mmdb
url: https://updates.maxmind.com/app/update_getfilename?product_id=GeoLite2-Country
md5hex_digest: 00000000000000000000000000000000
url: https://updates.maxmind.com/app/update_getipaddr
Client IP address: 39.110.218.162
md5hex_digest2 (challenge): cc0e7d8aeb29a3f811a87dceb5b73829
url: https://updates.maxmind.com/app/update_secure?db_md5=00000000000000000000000000000000&challenge_md5=cc0e7d8aeb29a3f811a87dceb5b73829&user_id=0&edition_id=GeoLite2-Country
Uncompress file /usr/share/GeoIP/GeoLite2-Country.mmdb.gz to /usr/share/GeoIP/GeoLite2-Country.mmdb.test
Rename /usr/share/GeoIP/GeoLite2-Country.mmdb.test to /usr/share/GeoIP/GeoLite2-Country.mmdb
```

Fixes #10 